### PR TITLE
Fix Claude CLI integration for latest SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,6 +1859,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2365,6 +2366,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary
- Updates `ClaudeSession.ts` to work with the latest Claude CLI API: switches to `stream-json` output format, `-p` pipe mode, and `bypassPermissions` permission mode
- Strips `ANTHROPIC_API_KEY` from the spawned env so the CLI uses OAuth instead, and closes stdin immediately to prevent hanging
- Applies the same fixes to both the main session runner and the handoff summary flow

## Test plan
- [ ] Verify Telegram bot starts and connects to Claude CLI successfully
- [ ] Send a message via Telegram and confirm Claude responds with streamed output
- [ ] Test session handoff/summary generation
- [ ] Confirm no API key conflicts between Telegram bot and Claude CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)