### PR TITLE
feat: rich tool activity tracking + session corruption recovery

### DIFF
--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -313,10 +313,19 @@ export interface AgentEvent {
   error?: string;
 }
 
+export interface ToolActivity {
+  id: string;
+  toolName: string;
+  summary: string;
+  status: "running" | "completed" | "error";
+  timestamp: number;
+}
+
 export interface WSCallbacks {
   onStream?: (content: string, messageId: string) => void;
   onComplete?: (messageId: string, message: unknown) => void;
   onToolCall?: (name: string, input: string) => void;
+  onToolActivity?: (messageId: string, activity: ToolActivity) => void;
   onError?: (error: string) => void;
   onPresence?: (state: PresenceState) => void;
   onTranscription?: (messageId: string, text: string) => void;
@@ -365,6 +374,9 @@ export function connect() {
           break;
         case "chat.tool_call":
           callbacks.onToolCall?.(msg.name, msg.input);
+          break;
+        case "chat.tool_activity":
+          callbacks.onToolActivity?.(msg.messageId, msg.activity);
           break;
         case "chat.error":
           callbacks.onError?.(msg.error);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -92,6 +92,15 @@ export interface Decision {
   revisedAt?: number;
 }
 
+// Tool activity — real-time visibility into agent tool use
+export interface ChatToolActivity {
+  id: string
+  toolName: string
+  summary: string
+  status: "running" | "completed" | "error"
+  timestamp: number
+}
+
 // WebSocket message types
 export type WSClientMessage =
   | { type: "chat"; content: string; projectId?: string }
@@ -103,6 +112,7 @@ export type WSServerMessage =
   | { type: "chat.stream"; content: string; messageId: string }
   | { type: "chat.complete"; messageId: string; message: Message }
   | { type: "chat.tool_call"; name: string; input: string }
+  | { type: "chat.tool_activity"; messageId: string; activity: ChatToolActivity }
   | { type: "chat.error"; error: string }
   | { type: "chat.handoff"; message: string }
   | { type: "chat.handoff_complete"; conversationId: string; message: string }


### PR DESCRIPTION
## Summary
- Adds real-time tool activity visibility to the web/mobile chat UI — users can see what the agent is doing (reading files, editing code, running commands) as it works
- Adds automatic session recovery when a resumed Claude CLI session is corrupted (detect failure → invalidate → retry fresh)
- Backwards-compatible: legacy `chat.tool_call` events still emitted alongside new `chat.tool_activity`

## Changes
| File | What |
|------|------|
| `packages/shared/src/types/index.ts` | `ChatToolActivity` type + `chat.tool_activity` WS message |
| `src/services/AppServer.ts` | Tool activity tracking, human-readable summaries, session corruption recovery |
| `apps/mobile/services/api.ts` | `onToolActivity` callback + WS handler |
| `apps/mobile/app/(tabs)/index.tsx` | `ToolActivityList` component, inline rendering under messages |

## Test plan
- [ ] Send message on maslow.teamaiden.ai → verify tool activity dots appear under assistant message
- [ ] Confirm running (purple), completed (green), error (red) status transitions
- [ ] Send follow-up message → verify session resumes (no fresh context)
- [ ] Kill a session file on disk, send message → verify corruption recovery (auto-retry with fresh session)
- [ ] Verify legacy `chat.tool_call` events still sent for any existing consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)